### PR TITLE
Add xamarin-gtk-theme build

### DIFF
--- a/slns/xamarin-gtk-theme/build/win32/vs12/config.h
+++ b/slns/xamarin-gtk-theme/build/win32/vs12/config.h
@@ -1,0 +1,93 @@
+/* src/config.h.  Generated from config.h.in by configure.  */
+/* src/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* always defined to indicate that i18n is enabled */
+#define ENABLE_NLS 1
+
+/* Gettext package */
+#define GETTEXT_PACKAGE "xamarin-gtk-theme"
+
+/* Defines whether to compile with animation support */
+/* #undef HAVE_ANIMATION */
+
+/* Defines whether to compile with progressbar animation from right to left */
+/* #undef HAVE_ANIMATIONRTL */
+
+/* Define to 1 if you have the `bind_textdomain_codeset' function. */
+#define HAVE_BIND_TEXTDOMAIN_CODESET 1
+
+/* Define to 1 if you have the `dcgettext' function. */
+#define HAVE_DCGETTEXT 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define if the GNU gettext() function is already present or preinstalled. */
+#define HAVE_GETTEXT 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define if your <locale.h> file defines LC_MESSAGES. */
+/* #undef HAVE_LC_MESSAGES */
+
+/* Define to 1 if you have the <locale.h> header file. */
+#define HAVE_LOCALE_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Defines whether to compile with rgba support */
+#define HAVE_RGBA 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "xamarin-gtk-theme"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "xamarin-gtk-theme"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "xamarin-gtk-theme 0.98.2"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "xamarin-gtk-theme"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "0.98.2"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "0.98.2"

--- a/slns/xamarin-gtk-theme/build/win32/vs12/libxamarin-build-defines.props
+++ b/slns/xamarin-gtk-theme/build/win32/vs12/libxamarin-build-defines.props
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="UserMacros">
+    <GTK_BASEPATH>..\..\..\..\..\..\install\gtk\$(Platform)</GTK_BASEPATH>
+	<GtkInclude>$(GTK_BASEPATH)\include;$(GTK_BASEPATH)\include\gtk-2.0;$(GTK_BASEPATH)\include\glib-2.0;$(GTK_BASEPATH)\include\gio-win32-2.0;$(GTK_BASEPATH)\include\pixman-1;$(GTK_BASEPATH)\include\gdk-pixbuf-2.0;$(GTK_BASEPATH)\include\atk-1.0;$(GTK_BASEPATH)\lib\glib-2.0\include;$(GTK_BASEPATH)\lib\gtk-2.0\include\;$(GTK_BASEPATH)\include\pango-1.0;</GtkInclude>
+	<GtkLibs>gtk-win32-2.0.lib;gdk-win32-2.0.lib;glib-2.0.lib;atk-1.0.lib;gdk_pixbuf-2.0.lib;gobject-2.0.lib;cairo.lib;pangocairo-1.0.lib;pixman-1.lib;pangowin32-1.0.lib;</GtkLibs>
+  </PropertyGroup>
+  <PropertyGroup>
+    <_PropertySheetDisplayName>builddefinesprops</_PropertySheetDisplayName>
+    <OutDir>$(SolutionDir)$(Configuration)\bin\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\obj\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(GtkInclude);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+	<Link>
+	  <AdditionalDependencies>$(GtkLibs);%(AdditionalDependencies)</AdditionalDependencies>
+	  <AdditionalLibraryDirectories>$(GTK_BASEPATH)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <BuildMacro Include="GtkInclude">
+      <Value>$(GtkInclude)</Value>
+    </BuildMacro>
+    <BuildMacro Include="GtkLibs">
+      <Value>$(GtkLibs)</Value>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/slns/xamarin-gtk-theme/build/win32/vs12/libxamarin.vcxproj
+++ b/slns/xamarin-gtk-theme/build/win32/vs12/libxamarin.vcxproj
@@ -1,0 +1,118 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{6305DFC6-9458-418F-9DC4-49B16228A558}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>libxamarin</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="libxamarin-build-defines.props" />
+    <Import Project="..\..\..\..\stack.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="libxamarin-build-defines.props" />
+    <Import Project="..\..\..\..\stack.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+	  <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+	  <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\src\animation.h" />
+    <ClInclude Include="..\..\..\src\cairo-support.h" />
+    <ClInclude Include="..\..\..\src\config.h" />
+    <ClInclude Include="..\..\..\src\exponential-blur.h" />
+    <ClInclude Include="..\..\..\src\gaussian-blur.h" />
+    <ClInclude Include="..\..\..\src\murrine_draw.h" />
+    <ClInclude Include="..\..\..\src\murrine_draw_rgba.h" />
+    <ClInclude Include="..\..\..\src\murrine_rc_style.h" />
+    <ClInclude Include="..\..\..\src\murrine_style.h" />
+    <ClInclude Include="..\..\..\src\murrine_types.h" />
+    <ClInclude Include="..\..\..\src\raico-blur.h" />
+    <ClInclude Include="..\..\..\src\stack-blur.h" />
+    <ClInclude Include="..\..\..\src\support.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\animation.c" />
+    <ClCompile Include="..\..\..\src\cairo-support.c" />
+    <ClCompile Include="..\..\..\src\exponential-blur.c" />
+    <ClCompile Include="..\..\..\src\gaussian-blur.c" />
+    <ClCompile Include="..\..\..\src\murrine_draw.c" />
+    <ClCompile Include="..\..\..\src\murrine_draw_rgba.c" />
+    <ClCompile Include="..\..\..\src\murrine_rc_style.c" />
+    <ClCompile Include="..\..\..\src\murrine_style.c" />
+    <ClCompile Include="..\..\..\src\murrine_theme_main.c" />
+    <ClCompile Include="..\..\..\src\raico-blur.c" />
+    <ClCompile Include="..\..\..\src\stack-blur.c" />
+    <ClCompile Include="..\..\..\src\support.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/slns/xamarin-gtk-theme/build/win32/vs12/libxamarin.vcxproj.filters
+++ b/slns/xamarin-gtk-theme/build/win32/vs12/libxamarin.vcxproj.filters
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR adds [xamarin-gtk-theme](https://github.com/mono/xamarin-gtk-theme) to the build.

**IMPORTANT:** libxamarin will be pulled from https://github.com/mono/xamarin-gtk-theme.git, but it requires https://github.com/mono/xamarin-gtk-theme/pull/23 (or at least sevoku/xamarin-gtk-theme@664c5a20bc8f0fc7df6864420e8809c5c2515c6d) to build with VS.

The commit can/should be cherry-picked to https://github.com/bratsche/gtk-build-shiz/tree/highdpi
